### PR TITLE
Prevent Null Object References When Calling DialogResultListener Methods

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -166,7 +166,9 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     @Override
     public void onAuthenticated() {
         this.isAuthInProgress = false;
-        this.dialogCallback.onAuthenticated();
+        if(this.dialogCallback != null){
+            this.dialogCallback.onAuthenticated();
+        }
         dismiss();
     }
 
@@ -181,7 +183,9 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     public void onCancelled() {
         this.isAuthInProgress = false;
         this.mFingerprintHandler.endAuth();
-        this.dialogCallback.onCancelled();
+        if(this.dialogCallback != null){
+            this.dialogCallback.onCancelled();
+        }
         dismiss();
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-touch-id",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "React Native authentication with the native Touch ID popup.",
   "scripts": {
     "lint": "node_modules/.bin/eslint .",


### PR DESCRIPTION
Based on naoufal#196